### PR TITLE
Added Firewall Logging SQL Example

### DIFF
--- a/samples/logging/firewall/firewall_source_dest_traffic_by_ip.sql
+++ b/samples/logging/firewall/firewall_source_dest_traffic_by_ip.sql
@@ -1,0 +1,35 @@
+/* Copyright 2023 Google LLC
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ https://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+SELECT
+ JSON_VALUE(json_payload.connection.src_ip) as src_ip,
+ JSON_VALUE(json_payload.src_vpc.vpc_name) as src_vpc_name,
+ JSON_VALUE(json_payload.src_instance.vm_name) as src_vm_name,
+ JSON_VALUE(json_payload.connection.dest_ip) as dest_ip,
+ JSON_VALUE(json_payload.dest_vpc.vpc_name) as dest_vpc_name,
+ JSON_VALUE(json_payload.dest_instance.vm_name) as dest_vm_name,
+ JSON_VALUE(json_payload.connection.protocol) as protocol,
+ JSON_VALUE(json_payload.connection.src_port) as src_port,
+ JSON_VALUE(json_payload.connection.dest_port) as dest_port,
+ JSON_VALUE(json_payload.rule_details.action) as action,
+ JSON_VALUE(json_payload.rule_details.direction) as direction,
+ MAX(timestamp) as timestamp,
+ SUM(CAST(JSON_VALUE(json_payload.bytes_sent) as INT64)) as total_bytes_sent
+FROM
+`[MY_PROJECT].global._Default._Default`
+WHERE
+log_id = "compute.googleapis.com/firewall"
+GROUP BY 1,2,3,4,5,6,7,8,9,10,11
+ORDER BY 12 DESC


### PR DESCRIPTION
# Description
This SQL query extracts and aggregates firewall logging data from Google Cloud's logging system. It retrieves details about network traffic, including source and destination IPs, VPC and VM names, protocols, ports, and firewall rule actions. The query also calculates the total bytes sent for each connection and returns the most recent timestamp for each grouped entry.

# Query Explanation
- JSON_VALUE(json_payload.connection.src_ip) as src_ip: Extracts the source IP address from the firewall log.
- JSON_VALUE(json_payload.src_vpc.vpc_name) as src_vpc_name: Retrieves the source VPC name.
- JSON_VALUE(json_payload.src_instance.vm_name) as src_vm_name: Gets the source VM name.
- JSON_VALUE(json_payload.connection.dest_ip) as dest_ip: Extracts the destination IP address.
- JSON_VALUE(json_payload.dest_vpc.vpc_name) as dest_vpc_name: Retrieves the destination VPC name.
- JSON_VALUE(json_payload.dest_instance.vm_name) as dest_vm_name: Gets the destination VM name.
- JSON_VALUE(json_payload.connection.protocol) as protocol: Extracts the network protocol used (e.g., TCP, UDP).
- JSON_VALUE(json_payload.connection.src_port) as src_port: Retrieves the source port number.
- JSON_VALUE(json_payload.connection.dest_port) as dest_port: Retrieves the destination port number.
- JSON_VALUE(json_payload.rule_details.action) as action: Specifies whether the firewall allowed or denied the traffic.
- JSON_VALUE(json_payload.rule_details.direction) as direction: Indicates if the traffic is inbound or outbound.
- MAX(timestamp) as timestamp: Retrieves the latest timestamp for each grouped connection.
- SUM(CAST(JSON_VALUE(json_payload.bytes_sent) as INT64)) as total_bytes_sent: Aggregates the total bytes sent for each connection.

# Filters & Grouping
- The query filters logs where log_id = "compute.googleapis.com/firewall", ensuring it only processes firewall-related logs.
- Data is grouped by source/destination IPs, VPCs, VMs, protocol, ports, action, and direction, providing a structured summary of firewall traffic.
- Results are ordered by the latest timestamp to display recent connections first.

This PR adds an example SQL query to analyze firewall logging data for enhanced network observability.