### PR TITLE
Add sample to correlate errors to root cause with combined views

### DIFF
--- a/samples/trace/README.md
+++ b/samples/trace/README.md
@@ -5,4 +5,6 @@
 | 1.2| [Extracts commonly used information from spans without any aggregation functions](./info_from_spans.sql)||
 | 1.3| [Extracts P95 latency info](./p95_latency.sql)| |
 | 1.4| [Finds failed tool calls and joins with logs to retrieve prompt and thoughts](./failed_tool_calls_with_logs.sql)| |
+| 1.5| [Join traces and logs to inspect error details for a specific method](./correlate_errors_to_root_cause.sql)| |
+
 

--- a/samples/trace/correlate_errors_to_root_cause.sql
+++ b/samples/trace/correlate_errors_to_root_cause.sql
@@ -1,0 +1,31 @@
+-- Join traces and logs to inspect error details for a specific method.
+-- Use Case 3: Correlate errors to root cause with combined views
+-- Imagine seeing a spike in errors in your logs. With a combined log and trace
+-- view, you can instantly filter for the traces associated with those errors.
+-- This allows you to visualize the entire request path that led to the failure,
+-- including the services involved, request parameters, and timing for each step,
+-- dramatically reducing your mean time to resolution (MTTR).
+
+SELECT
+  t.trace_id,
+  t.span_id,
+  t.name AS method_name,
+  t.duration_nano / 1000000 AS latency_ms,
+  l.timestamp,
+  l.severity,
+  JSON_VALUE(l.json_payload.errorMessage) AS error_message
+FROM
+  `YOUR_PROJECT_ID.us._Trace.Spans._AllSpans` AS t
+JOIN
+  `YOUR_PROJECT_ID.us._Default._AllLogs` AS l
+ON
+  -- Extract trace_id from the full trace path in _AllLogs
+  t.trace_id = SPLIT(l.trace, '/')[SAFE_OFFSET(3)]
+  -- Match span_id (note camelCase spanId in _AllLogs)
+  AND t.span_id = l.spanId
+WHERE
+  t.name = 'YourService.YourMethod'
+  AND t.status.code = 2
+  AND l.severity = 'ERROR'
+ORDER BY
+  l.timestamp DESC


### PR DESCRIPTION
Imagine seeing a spike in errors in your logs. With a combined log and trace view, you can instantly filter for the traces associated with those errors. This allows you to visualize the entire request path that led to the failure, including the services involved, request parameters, and timing for each step, dramatically reducing your mean time to resolution (MTTR).
