### PR TITLE
Add sample to identify latency impact on specific customers

### DIFF
--- a/samples/trace/README.md
+++ b/samples/trace/README.md
@@ -5,4 +5,6 @@
 | 1.2| [Extracts commonly used information from spans without any aggregation functions](./info_from_spans.sql)||
 | 1.3| [Extracts P95 latency info](./p95_latency.sql)| |
 | 1.4| [Finds failed tool calls and joins with logs to retrieve prompt and thoughts](./failed_tool_calls_with_logs.sql)| |
+| 1.5| [Find the top 10 customers experiencing the highest 95th percentile latency](./customer_latency_impact.sql)| |
+
 

--- a/samples/trace/customer_latency_impact.sql
+++ b/samples/trace/customer_latency_impact.sql
@@ -1,0 +1,28 @@
+-- Find the top 10 customers experiencing the highest 95th percentile latency.
+-- Use Case 4: Identify latency impact on specific customers (Business Context)
+-- If you don't propagate user or customer identifiers in your trace attributes
+-- (e.g., for privacy or technical reasons), but you do log them in your
+-- application access logs, you can join traces and logs to identify which
+-- customers are experiencing the worst performance.
+
+SELECT
+  JSON_VALUE(l.json_payload.customer_id) AS customer_id,
+  AVG(t.duration_nano / 1000000) AS avg_latency_ms,
+  APPROX_QUANTILES(t.duration_nano / 1000000, 100)[OFFSET(95)] AS p95_latency_ms,
+  COUNT(t.span_id) AS total_requests
+FROM
+  `YOUR_PROJECT_ID.us._Trace.Spans._AllSpans` AS t
+JOIN
+  `YOUR_PROJECT_ID.us._Default._AllLogs` AS l
+ON
+  t.trace_id = SPLIT(l.trace, '/')[SAFE_OFFSET(3)]
+  AND t.span_id = l.spanId
+WHERE
+  t.start_time BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY) AND CURRENT_TIMESTAMP()
+  AND t.kind.name = 'SPAN_KIND_SERVER'
+  AND JSON_VALUE(l.json_payload.customer_id) IS NOT NULL
+GROUP BY
+  customer_id
+ORDER BY
+  p95_latency_ms DESC
+LIMIT 10


### PR DESCRIPTION
If you don't propagate user or customer identifiers in your trace attributes (e.g., for privacy or technical reasons), but you do log them in your application access logs, you can join traces and logs to identify which customers are experiencing the worst performance.
